### PR TITLE
fix: Closes #1 now --force is only for init cmd

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -48,7 +48,7 @@ var initCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(initCmd)
-	rootCmd.PersistentFlags().BoolVarP(&Force, "force", "f", false, "Force to overwrite existing file")
+	initCmd.Flags().BoolVarP(&Force, "force", "f", false, "Force overwriting of the resources.json file")
 
 	WorkingDirectory = workingdirectory.GetWorkingDirectory()
 	ResourcesFile = WorkingDirectory + string(os.PathSeparator) + "resources.json"


### PR DESCRIPTION
Closes #1 
Now the --force flag is only for the init command